### PR TITLE
Ensure we grant bucket owner full control on the object

### DIFF
--- a/src/main/scala/com/gu/repoapocalypse/Archive.scala
+++ b/src/main/scala/com/gu/repoapocalypse/Archive.scala
@@ -5,6 +5,8 @@ import java.util.zip.{ZipEntry, ZipOutputStream}
 
 import com.amazonaws.regions.Regions
 import com.amazonaws.services.s3.AmazonS3ClientBuilder
+import com.amazonaws.services.s3.model.PutObjectRequest
+import com.amazonaws.services.s3.model.CannedAccessControlList
 import fs2.{Strategy, Task}
 import org.eclipse.jgit.api.Git
 import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider
@@ -26,7 +28,10 @@ object Archive {
     val prefixWithSlash = if (trimmedPrefix.isEmpty) "" else s"$trimmedPrefix/"
     val locationDescription = s"s3://$bucket/$prefixWithSlash${path.getFileName}"
     Task {
-      client.putObject(bucket, s"$prefixWithSlash${path.getFileName}", path.toFile)
+      val baseRequest = new PutObjectRequest(bucket, s"$prefixWithSlash${path.getFileName}", path.toFile)
+      /* Ensure the bucket owner is granted read and write access to the file */
+      val request = baseRequest.withCannedAcl(CannedAccessControlList.BucketOwnerFullControl)
+      client.putObject(request)
       locationDescription
     }
   }


### PR DESCRIPTION
Currently it is impossible to retrieve an archived repository using `Root`AWS account credentials or using [`guGitArchiveS3BucketReadAccess`](https://github.com/guardian/janus/blob/master/guData/src/main/scala/com/gu/janus/data/BespokePolicies.scala#L51) bespoke policy because Objects are put with the `Deploy Tools` account.

This is not intuitive and the only way to access those files is through getting `Deploy Tools` account credentials and retrieving the files through the command line. I think this issue has been experienced by other people before as I found a branch from @jharewinton with similar commit 048c0e4e104c1b4ce4361785830f2a99d66966ad.

The associated change ensure that at time of the archive, the bucket owner (`root` in our case) is granted full ownership on the files. 



@tomrf1 @JustinPinner @philmcmahon